### PR TITLE
Add auth script to help replace AWS keys

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -32,7 +32,6 @@ fi
 HOMEBREW_PREFIX="/usr/local"
 
 mkdir -p $HOMEBREW_PREFIX
-sudo chown -R "$LOGNAME" $HOMEBREW_PREFIX/*
 
 if command -v aws 2>/dev/null; then
   fancy_echo "AWS CLI already installed. Continuing…"

--- a/vault_aws.sh
+++ b/vault_aws.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo " 🔐 Initiating AWS auth through Vault 🔐 "
+
+if [ -z "$GIT_TOKEN" ]; then
+  echo >&2 'error: missing GIT_TOKEN environment variable. Create one here: https://github.com/settings/tokens' && exit 1
+fi
+
+vault login -method=github token=$GIT_TOKEN
+vault read aws/creds/dev > temp
+
+cat ./temp
+
+export AWS_ACCESS_KEY_ID=$(sed -n 6p temp | sed 's/.* //g')
+export AWS_SECRET_ACCESS_KEY=$(sed -n 7p temp | sed 's/.* //g')
+
+echo "\nWriting to .aws/credentials…"
+
+cp ~/.aws/credentials ~/.aws/deprecated_creds
+
+cat >~/.aws/credentials <<EOF
+[default]
+aws_access_key_id=${AWS_ACCESS_KEY_ID}
+aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+EOF
+
+rm ./temp
+
+echo "Successfully updated your AWS creds.\n"


### PR DESCRIPTION
`sh path/to/laptop/vault_auth.sh`

@danfitz36 Here is the script that I use to replace my keys.

Your aws keys will always live at `~/.aws/credentials`, and we hang on to last months after the script runs just in case something fails.

also resolves #6 