### PR TITLE
explicit version of node, and ensure it installs before yarn pulls in node@12 as dependency

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -74,8 +74,8 @@ brew "openssl"
 brew "hub"
 
 # Programming languages and package managers
+brew "node@10" # install node@10 or node@11 first; yarn auto-installs node@12 as a dependency, which doesn't work nicely with our assets.
 brew "yarn"
-brew "node"
 brew "elixir"
 brew "rebar"
 


### PR DESCRIPTION
swap install order of node and yarn, since yarn auto-installs node@12 as a dependency. We need node@10 or node@11 for Crowbar, so specify a version we know works, and make sure it's first on the PATH.