### PR TITLE
fixed vault script

### DIFF
--- a/vault_aws.zsh
+++ b/vault_aws.zsh
@@ -13,6 +13,10 @@ if [ -z "$GIT_TOKEN" ]; then
   echo >&2 'error: missing GIT_TOKEN environment variable. Create one here: https://github.com/settings/tokens' && exit 1
 fi
 
+if [ -z "$VAULT_ADDR" ]; then
+  echo -e "\nexport VAULT_ADDR=https://vault.corvusinsurance.com" >> ~/.zshrc
+fi
+
 vault login -method=github token=$GIT_TOKEN
 vault read aws/creds/dev > temp
 
@@ -34,9 +38,6 @@ aws_access_key_id=${AWS_ACCESS_KEY_ID}
 aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
 EOF
 
-if [ -z "$VAULT_ADDR" ]; then
-  echo -e "\nexport VAULT_ADDR=https://vault.corvusinsurance.com" >> ~/.zshrc
-fi
 
 rm ./temp
 


### PR DESCRIPTION
The if statement that checks for `$VAULT_ADDR` was moved up beneath the if statement that checks for `$GIT_TOKEN` so that the vault address could be compiled. The shell was crashing because it could not identify the environmental variable for the vault address (`$VAULT_ADDR`) in order to run the script.