### PR TITLE
Install vault from hashicorp tap

### DIFF
--- a/laptop.zsh
+++ b/laptop.zsh
@@ -64,6 +64,7 @@ fancy_echo "Updating Homebrew formulae ..."
 brew update
 brew bundle --file=- <<EOF
 tap "homebrew/services"
+tap "hashicorp/tap"
 
 # Unix
 brew "ctags"
@@ -78,7 +79,7 @@ brew "node@10" # install node@10 or node@11 first; yarn auto-installs node@12 as
 brew "yarn"
 brew "rebar"
 
-brew "vault"
+brew "hashicorp/tap/vault"
 cask "graphiql"
 brew "postgresql", restart_service: true
 EOF


### PR DESCRIPTION
We should prefer to use the hashicorp tools directly released from relatively new [hashicorp/tap](https://www.hashicorp.com/blog/announcing-hashicorp-homebrew-tap).

### Migrating

To migrate without re-running the laptop script

```
brew uninstall vault
brew tap hashicorp/tap
brew install hashicorp/tap/vault
```