### PR TITLE
Move awscli to homebrew and use v2, use updated homebrew install method, and a few other quick fixes

### DIFF
--- a/asdf/.tool-versions
+++ b/asdf/.tool-versions
@@ -1,6 +1,5 @@
-elixir 1.10.2
+elixir 1.11.2
+erlang 23.1.1
 elm 0.19.1
-erlang 22.3.4
-nodejs 10.17.0
 python 3.7.3 2.7.16
-rust 1.39.0
+rust 1.47.0

--- a/laptop.zsh
+++ b/laptop.zsh
@@ -33,14 +33,6 @@ HOMEBREW_PREFIX="/usr/local"
 
 mkdir -p $HOMEBREW_PREFIX
 
-if command -v aws 2>/dev/null; then
-  fancy_echo "AWS CLI already installed. Continuing…"
-else
-  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o ~/Downloads/awscli-bundle.zip
-  unzip ~/Downloads/awscli-bundle.zip -d ~/Downloads
-  sudo ~/Downloads/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-fi
-
 if command -v xcodebuild 2>/dev/null; then
   fancy_echo "Xcode already installed. Continuing…"
 else
@@ -51,11 +43,10 @@ fi
 
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
-    curl -fsS \
-      'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
-if brew list | grep -Fq brew-cask; then
+if brew list --formula | grep -Fq brew-cask; then
   fancy_echo "Uninstalling old Homebrew-Cask ..."
   brew uninstall --force brew-cask
 fi
@@ -70,12 +61,14 @@ tap "hashicorp/tap"
 brew "ctags"
 brew "git"
 brew "openssl"
+brew "awscli"
+brew "pre-commit"
 
 # GitHub
-brew "hub"
+brew "gh"
 
 # Programming languages and package managers
-brew "node@10" # install node@10 or node@11 first; yarn auto-installs node@12 as a dependency, which doesn't work nicely with our assets.
+brew "node"
 brew "yarn"
 brew "rebar"
 
@@ -83,6 +76,7 @@ brew "hashicorp/tap/vault"
 cask "graphiql"
 brew "postgresql", restart_service: true
 EOF
+brew link vault
 
 fancy_echo "Installing Elm…"
 yarn global add elm --prefix /usr/local


### PR DESCRIPTION
I had a chance to re-run the laptop scripts from scratch today and found a few bugs that I've fixed:

* Changed aws cli from manual install to homebrew and use awscli v2
* Updated .tool-versions from current crowbar versions
* Add `pre-commit` brew formula for git pre-commit hooks
* Changed github brew install from `hub` to `gh` to use the new release
* Unpinned node at v10 because newer versions work fine now
* Run `brew link vault` because it needed to be manually run afterwords
